### PR TITLE
Disable default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 deadpool = { version = "0.9.3", features = ["managed", "rt_tokio_1"] }
 diesel = { version = "2.0.0-rc.0", default-features = false }
-diesel-async = { git = "https://github.com/weiznich/diesel_async", rev = "a06d74e" }
+diesel-async = { git = "https://github.com/weiznich/diesel_async", rev = "a06d74e", default-features = false }
 thiserror = "1.0.30"
 tokio = "1.17.0"
 


### PR DESCRIPTION
Prevent mysql_async becoming a dependency when using the postgres feature flag and
vice versa.